### PR TITLE
rename 'representation' to 'reference'

### DIFF
--- a/build/ref-ontology.ttl
+++ b/build/ref-ontology.ttl
@@ -35,9 +35,9 @@ ref:IFCReference a owl:Class,
             sh:minCount 1 ;
             sh:path ifc:hasProjectReference ] .
 
-ref:hasExternalRepresentation a owl:ObjectProperty,
+ref:hasExternalReference a owl:ObjectProperty,
         sh:PropertyShape ;
-    rdfs:label "hasExternalRepresentation" ;
+    rdfs:label "hasExternalReference" ;
     skos:definition "" ;
     sh:class ref:ExternalReference .
 

--- a/examples/ex1.ttl
+++ b/examples/ex1.ttl
@@ -16,12 +16,12 @@
     bacnet:hasPort [ a bacnet:Port ; bacnet:value 47808 ] .
 
 :xyz a s223:Property ;
-  ref:hasExternalRepresentation [
+  ref:hasExternalReference [
     a ref:TimeseriesReference ;
     tsdb:hasTimeseriesId "4665117e-ec75-47c2-a5ce-b71529cb159e" ;
     tsdb:storedAt "postgresql://dataserver/sensordatadb" ;
   ] ;
-  ref:hasExternalRepresentation [
+  ref:hasExternalReference [
     a ref:BACnetReference ;
     bacnet:object-identifier "analog-value,5" ;
     bacnet:object-name "BLDG-Z410-ZATS" ;

--- a/model/core.ttl
+++ b/model/core.ttl
@@ -16,8 +16,8 @@ ref:ExternalReference
   skos:definition "";
 .
 
-ref:hasExternalRepresentation a owl:ObjectProperty, sh:PropertyShape ;
+ref:hasExternalReference a owl:ObjectProperty, sh:PropertyShape ;
     sh:class ref:ExternalReference ;
-    rdfs:label "hasExternalRepresentation" ;
+    rdfs:label "hasExternalReference" ;
     skos:definition "" ;
 .


### PR DESCRIPTION
I like the term "reference" and this update makes it consistent with **hasTimeseriesReference**.