### PR TITLE
Use single namespace for all outward-facing properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# compiled docs
+doc.html
+
 # ontoenv stuff
 .ontoenv/
 

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ compile: model/*.ttl test
 
 test:
 	poetry run pytest -s -vvvv
+
+docs: compile
+	poetry run pylode build/ref-schema.ttl -o doc.html

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ test:
 	poetry run pytest -s -vvvv
 
 docs: compile
-	poetry run pylode build/ref-schema.ttl -o doc.html
+	poetry run pylode build/ref-schema.ttl -o doc.html -c true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Ref Schema
+
+Docs are [here](https://ref-schema.brickschema.org/#BACnetReference)

--- a/examples/ex1.ttl
+++ b/examples/ex1.ttl
@@ -2,7 +2,6 @@
 @prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix s223: <http://data.ashrae.org/standard223#> .
 @prefix bacnet: <http://data.ashrae.org/bacnet/2020#> .
-@prefix tsdb: <https://brickschema.org/schema/Brick/ref/tsdb#> .
 @prefix : <urn:ex1> .
 
 <urn:ex1>
@@ -18,8 +17,8 @@
 :xyz a s223:Property ;
   ref:hasExternalReference [
     a ref:TimeseriesReference ;
-    tsdb:hasTimeseriesId "4665117e-ec75-47c2-a5ce-b71529cb159e" ;
-    tsdb:storedAt "postgresql://dataserver/sensordatadb" ;
+    ref:hasTimeseriesId "4665117e-ec75-47c2-a5ce-b71529cb159e" ;
+    ref:storedAt "postgresql://dataserver/sensordatadb" ;
   ] ;
   ref:hasExternalReference [
     a ref:BACnetReference ;

--- a/model/all.ttl
+++ b/model/all.ttl
@@ -1,3 +1,5 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix sdo: <http://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -9,7 +11,11 @@
 @prefix ifc: <https://brickschema.org/schema/Brick/ref/ifc#> .
 @prefix tsdb: <https://brickschema.org/schema/Brick/ref/tsdb#> .
 
-ref: a owl:Ontology ;
+<https://brickschema.org/schema/Brick/ref> a owl:Ontology ;
+    dcterms:title "Ref Schema" ;
+    dcterms:creator ( [ a sdo:Person ;
+                sdo:email "gtfierro@mines.edu" ;
+                sdo:name "Gabe Fierro" ] ) ;
     owl:imports <https://brickschema.org/schema/Brick/ref/core#> ;
     owl:imports <https://brickschema.org/schema/Brick/ref/bacnet#> ;
     owl:imports <https://brickschema.org/schema/Brick/ref/ifc#> ;

--- a/model/all.ttl
+++ b/model/all.ttl
@@ -24,6 +24,7 @@
 
 ref:BACnetReference a owl:Class,
         sh:NodeShape ;
+    skos:definition "A reference to the BACnet object represented by this entity." ;
     rdfs:subClassOf ref:ExternalReference ;
     sh:or ( [ sh:property [ a sh:PropertyShape ;
                         sh:datatype xsd:string ;
@@ -53,6 +54,7 @@ ref:BACnetReference a owl:Class,
 
 ref:IFCReference a owl:Class,
         sh:NodeShape ;
+    skos:definition "A reference to an entity in an IFC project which may contain additional metadata about this entity." ;
     rdfs:subClassOf ref:ExternalReference ;
     sh:property [ a sh:PropertyShape ;
             skos:definition "Name of the entity in IFC" ;
@@ -71,6 +73,7 @@ ref:IFCReference a owl:Class,
 
 ref:TimeseriesReference a owl:Class,
         sh:NodeShape ;
+    skos:definition "A reference to a stream of timeseries data in a database. Contains the data for this entity" ;
     rdfs:subClassOf ref:ExternalReference ;
     sh:property [ a sh:PropertyShape ;
             skos:definition "The identifier for the timeseries data corresponding to this point" ;

--- a/model/all.ttl
+++ b/model/all.ttl
@@ -51,17 +51,17 @@ ref:IFCReference a owl:Class,
     sh:property [ a sh:PropertyShape ;
             skos:definition "Name of the entity in IFC" ;
             sh:datatype xsd:string ;
-            sh:path ifc:name ],
+            sh:path ref:ifcName ],
         [ a sh:PropertyShape ;
             skos:definition "The global ID of the entity in the IFC project" ;
             sh:datatype xsd:string ;
             sh:minCount 1 ;
-            sh:path ifc:globalID ],
+            sh:path ref:ifcGlobalID ],
         [ a sh:PropertyShape ;
             skos:definition "Reference to an IFC Project object, containing the project ID" ;
-            sh:class ifc:Project ;
+            sh:class ref:ifcProject ;
             sh:minCount 1 ;
-            sh:path ifc:hasProjectReference ] .
+            sh:path ref:hasIfcProjectReference ] .
 
 ref:TimeseriesReference a owl:Class,
         sh:NodeShape ;
@@ -70,9 +70,9 @@ ref:TimeseriesReference a owl:Class,
             skos:definition "The identifier for the timeseries data corresponding to this point" ;
             sh:datatype xsd:string ;
             sh:minCount 1 ;
-            sh:path tsdb:hasTimeseriesId ],
+            sh:path ref:hasTimeseriesId ],
         [ a sh:PropertyShape ;
             skos:definition "Refers to a database storing the timeseries data for the related point. Properties on this class are *to be determined*; feel free to add arbitrary properties onto Database instances for your particular deployment" ;
             sh:datatype xsd:string ;
-            sh:path tsdb:storedAt ] .
+            sh:path ref:storedAt ] .
 

--- a/model/bacnet.ttl
+++ b/model/bacnet.ttl
@@ -9,7 +9,7 @@
 @prefix bacnetref: <https://brickschema.org/schema/Brick/ref/bacnet#> .
 
 bacnetref: a owl:Ontology ;
-    owl:imports bacnet: ;
+    owl:imports <http://data.ashrae.org/bacnet/2020> ;
 .
 
 

--- a/model/bacnet.ttl
+++ b/model/bacnet.ttl
@@ -10,8 +10,8 @@
 
 bacnetref: a owl:Ontology ;
     owl:imports bacnet: ;
-    owl:imports <https://brickschema.org/schema/Brick/ref/core#> ;
 .
+
 
 ###### BACnetReference
 bacnet:description a bacnet:StandardProperty,
@@ -50,10 +50,10 @@ bacnet:object-type a bacnet:StandardProperty,
 
 bacnet:objectOf a owl:ObjectProperty .
 
-bacnetref:read-property a owl:DatatypeProperty .
-bacnetref:BACnetURI a owl:DatatypeProperty .
+ref:bacnet-read-property a owl:DatatypeProperty .
+ref:BACnetURI a owl:DatatypeProperty .
 
-bacnetref:BACnetReferenceShape a sh:NodeShape ;
+ref:BACnetReferenceShape a sh:NodeShape ;
     sh:targetObjectsOf ref:hasExternalReference ;
     sh:rule [
       a sh:TripleRule ;

--- a/model/bacnet.ttl
+++ b/model/bacnet.ttl
@@ -16,6 +16,7 @@ bacnetref: a owl:Ontology ;
 ###### BACnetReference
 bacnet:description a bacnet:StandardProperty,
         owl:DatatypeProperty ;
+    skos:definition "The content of the description field of the BACnet object." ;
     bacnet:propertyEnum bacnet:PropertyIdentifier-description ;
     bacnet:propertyName "description" ;
     bacnet:propertyRef bacnet:Description .
@@ -23,6 +24,7 @@ bacnet:description a bacnet:StandardProperty,
 bacnet:object-identifier a bacnet:StandardProperty,
         rdf:Property,
         owl:DatatypeProperty ;
+    skos:definition "The BACnet object identifier" ;
     rdfs:label "object-identifier" ;
     bacnet:propertyEnum bacnet:PropertyIdentifier-object-identifier ;
     bacnet:propertyName "object-identifier" ;
@@ -32,6 +34,7 @@ bacnet:object-identifier a bacnet:StandardProperty,
 
 bacnet:object-name a bacnet:StandardProperty,
         owl:DatatypeProperty ;
+    skos:definition "The content of the name field of the BACnet object." ;
     bacnet:propertyEnum bacnet:PropertyIdentifier-object-name ;
     bacnet:propertyName "object-name" ;
     bacnet:propertyOf bacnet:Object ;
@@ -41,6 +44,7 @@ bacnet:object-name a bacnet:StandardProperty,
 bacnet:object-type a bacnet:StandardProperty,
         rdf:Property,
         owl:DatatypeProperty ;
+    skos:definition "The type of the BACnet object" ;
     rdfs:label "object-type" ;
     bacnet:propertyEnum bacnet:PropertyIdentifier-object-type ;
     bacnet:propertyName "object-type" ;
@@ -48,13 +52,24 @@ bacnet:object-type a bacnet:StandardProperty,
     bacnet:propertyRef bacnet:Object_Type ;
     rdfs:subPropertyOf bacnet:ReadableProperty .
 
-bacnet:objectOf a owl:ObjectProperty .
+bacnet:objectOf a owl:ObjectProperty ;
+    rdfs:label "objectOf" ;
+    rdfs:range bacnet:BACnetDevice ;
+    rdfs:comment "The 'parent' BACnet device that hosts this BACnet object." ;
+.
 
-ref:bacnet-read-property a owl:DatatypeProperty .
-ref:BACnetURI a owl:DatatypeProperty .
+ref:bacnet-read-property a owl:DatatypeProperty ;
+    rdfs:label "bacnet-read-property" ;
+    rdfs:comment "The property of the BACnet object to read to get the current value of this entity." ;
+.
+ref:BACnetURI a owl:DatatypeProperty ;
+    rdfs:label "BACnetURI" ;
+    rdfs:comment "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]" ;
+.
 
 ref:BACnetReferenceShape a sh:NodeShape ;
     sh:targetObjectsOf ref:hasExternalReference ;
+    skos:definition "Infers a BACnetReference instance from the object of an hasExternalReference." ;
     sh:rule [
       a sh:TripleRule ;
       sh:condition ref:BACnetReference ;

--- a/model/core.ttl
+++ b/model/core.ttl
@@ -13,15 +13,10 @@ ref:ExternalReference
   a owl:Class ;
   a sh:NodeShape ;
   rdfs:label "External reference" ;
-  skos:definition "";
+  skos:definition "The parent class of all external reference types";
 .
 
 ref:hasExternalReference a owl:ObjectProperty ;
     rdfs:label "hasExternalReference" ;
-    skos:definition "" ;
-.
-
-core:ExternalReferenceShape a sh:NodeShape ;
-    sh:targetObjectsOf ref:hasExternalReference ;
-    sh:class ref:ExternalReference ;
+    skos:definition "Points to the external reference for this entity, which contains additional metadata/data not included in this graph." ;
 .

--- a/model/ifc.ttl
+++ b/model/ifc.ttl
@@ -7,19 +7,17 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix ifc: <https://brickschema.org/schema/Brick/ref/ifc#> .
 
-ifc: a owl:Ontology ;
-    owl:imports <https://brickschema.org/schema/Brick/ref/core#> ;
-.
+ifc: a owl:Ontology .
 
-ifc:hasProjectReference a owl:ObjectProperty .
+ref:hasIfcProjectReference a owl:ObjectProperty .
 
-ifc:globalID a owl:DatatypeProperty ;
+ref:ifcGlobalID a owl:DatatypeProperty ;
     rdfs:range xsd:string .
 
-ifc:name a owl:DatatypeProperty ;
+ref:ifcName a owl:DatatypeProperty ;
     rdfs:range xsd:string .
 
-ifc:IFCReferenceShape a sh:NodeShape ;
+ref:IFCReferenceShape a sh:NodeShape ;
     sh:targetObjectsOf ref:hasExternalReference ;
     sh:rule [
       a sh:TripleRule ;

--- a/model/ifc.ttl
+++ b/model/ifc.ttl
@@ -9,15 +9,23 @@
 
 ifc: a owl:Ontology .
 
-ref:hasIfcProjectReference a owl:ObjectProperty .
+ref:hasIfcProjectReference a owl:ObjectProperty ;
+    rdfs:label "hasIfcProjectReference" ;
+    skos:definition "A reference to the IFC Project that defines this entity" ;
+.
 
 ref:ifcGlobalID a owl:DatatypeProperty ;
+    rdfs:label "ifcGlobalID" ;
+    skos:definition "The IFC Global ID of the entity" ;
     rdfs:range xsd:string .
 
 ref:ifcName a owl:DatatypeProperty ;
+    rdfs:label "ifcName" ;
+    skos:definition "The name of the IFC entity" ;
     rdfs:range xsd:string .
 
 ref:IFCReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a IFCReference instance from the object of an hasExternalReference." ;
     sh:targetObjectsOf ref:hasExternalReference ;
     sh:rule [
       a sh:TripleRule ;

--- a/model/tsdb.ttl
+++ b/model/tsdb.ttl
@@ -12,19 +12,22 @@ tsdb: a owl:Ontology .
 ref:hasTimeseriesReference a owl:ObjectProperty;
     sh:class ref:TimeseriesReference ;
     rdfs:subPropertyOf ref:hasExternalReference ;
-    skos:definition "Metadata for accessing related timeseries data",
-        "Relates a Brick point to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
+    rdfs:label "hasTimeseriesReference" ;
+    skos:definition "Metadata for accessing related timeseries data: Relates a Brick point to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
 
 ref:storedAt a owl:DatatypeProperty ;
     rdfs:range xsd:anyURI ;
+    rdfs:label "storedAt" ;
     skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
 
 ref:hasTimeseriesId a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
+    rdfs:label "hasTimeseriesId" ;
     skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
 
 ref:TimeseriesReferenceShape a sh:NodeShape ;
     sh:targetObjectsOf ref:hasExternalReference ;
+    skos:definition "Infers a TimeseriesReference instance from the object of an hasExternalReference." ;
     sh:rule [
       a sh:TripleRule ;
       sh:condition ref:TimeseriesReference ;

--- a/model/tsdb.ttl
+++ b/model/tsdb.ttl
@@ -7,9 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix tsdb: <https://brickschema.org/schema/Brick/ref/tsdb#> .
 
-tsdb: a owl:Ontology ;
-  owl:imports <https://brickschema.org/schema/Brick/ref/core#> ;
-.
+tsdb: a owl:Ontology .
 
 ref:hasTimeseriesReference a owl:ObjectProperty;
     sh:class ref:TimeseriesReference ;
@@ -17,15 +15,15 @@ ref:hasTimeseriesReference a owl:ObjectProperty;
     skos:definition "Metadata for accessing related timeseries data",
         "Relates a Brick point to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
 
-tsdb:storedAt a owl:DatatypeProperty ;
+ref:storedAt a owl:DatatypeProperty ;
     rdfs:range xsd:anyURI ;
     skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
 
-tsdb:hasTimeseriesId a owl:DatatypeProperty ;
+ref:hasTimeseriesId a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
 
-tsdb:TimeseriesReferenceShape a sh:NodeShape ;
+ref:TimeseriesReferenceShape a sh:NodeShape ;
     sh:targetObjectsOf ref:hasExternalReference ;
     sh:rule [
       a sh:TripleRule ;

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,6 +68,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "dominate"
+version = "2.6.0"
+description = "Dominate is a Python library for creating and manipulating HTML documents using an elegant DOM API."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "fonttools"
 version = "4.29.0"
 description = "Tools to manipulate font files"
@@ -139,6 +147,20 @@ description = "A fast implementation of the Cassowary constraint solver"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "markdown"
+version = "3.3.6"
+description = "Python implementation of Markdown."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
+
+[package.extras]
+testing = ["coverage", "pyyaml"]
 
 [[package]]
 name = "matplotlib"
@@ -276,6 +298,19 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
 pyparsing = ">=2.1.4"
+
+[[package]]
+name = "pylode"
+version = "3.0.1"
+description = "An OWL ontology documentation tool using Python and templating, based on LODE."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+dominate = "*"
+markdown = "*"
+rdflib = "*"
 
 [[package]]
 name = "pyparsing"
@@ -460,7 +495,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6199036d85e2cc969f284b5d3f7d33b348a5c6df5049e27076725c033ef693f4"
+content-hash = "50936442c9b6346b5db6858483702a188876664496d2be891da4db4db9cc96fe"
 
 [metadata.files]
 atomicwrites = [
@@ -490,6 +525,10 @@ colorama = [
 cycler = [
     {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
+]
+dominate = [
+    {file = "dominate-2.6.0-py2.py3-none-any.whl", hash = "sha256:84b5f71ed30021193cb0faa45d7776e1083f392cfe67a49f44e98cb2ed76c036"},
+    {file = "dominate-2.6.0.tar.gz", hash = "sha256:76ec2cde23700a6fc4fee098168b9dee43b99c2f1dd0ca6a711f683e8eb7e1e4"},
 ]
 fonttools = [
     {file = "fonttools-4.29.0-py3-none-any.whl", hash = "sha256:ed9496e5650b977a697c50ac99c8e8331f9eae3f99e5ae649623359103306dfe"},
@@ -556,6 +595,10 @@ kiwisolver = [
     {file = "kiwisolver-1.3.2-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25405f88a37c5f5bcba01c6e350086d65e7465fd1caaf986333d2a045045a223"},
     {file = "kiwisolver-1.3.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bcadb05c3d4794eb9eee1dddf1c24215c92fb7b55a80beae7a60530a91060560"},
     {file = "kiwisolver-1.3.2.tar.gz", hash = "sha256:fc4453705b81d03568d5b808ad8f09c77c47534f6ac2e72e733f9ca4714aa75c"},
+]
+markdown = [
+    {file = "Markdown-3.3.6-py3-none-any.whl", hash = "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"},
+    {file = "Markdown-3.3.6.tar.gz", hash = "sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006"},
 ]
 matplotlib = [
     {file = "matplotlib-3.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:456cc8334f6d1124e8ff856b42d2cc1c84335375a16448189999496549f7182b"},
@@ -689,6 +732,10 @@ py = [
 pydot = [
     {file = "pydot-1.4.2-py2.py3-none-any.whl", hash = "sha256:66c98190c65b8d2e2382a441b4c0edfdb4f4c025ef9cb9874de478fb0793a451"},
     {file = "pydot-1.4.2.tar.gz", hash = "sha256:248081a39bcb56784deb018977e428605c1c758f10897a339fce1dd728ff007d"},
+]
+pylode = [
+    {file = "pyLODE-3.0.1-py2.py3-none-any.whl", hash = "sha256:39e7e8c78f121d44634740fb9682fc13738f0b7f5d4d4e4d8875c850bbf62127"},
+    {file = "pyLODE-3.0.1.tar.gz", hash = "sha256:2dd5359570bfea1bec7f89b49be4893d0ae7829d50b437845ecac13d835297da"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pyshacl = "^0.18"
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"
 ontoenv = "^0.2"
+pyLODE = "^3.0.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tools/compile.py
+++ b/tools/compile.py
@@ -6,6 +6,7 @@ graph = rdflib.Graph()
 graph.parse("model/all.ttl", format="ttl")
 env.import_dependencies(graph)
 # clean up ontology defs and their imports that aren't the core 'ref' schema
+graph.remove((None, rdflib.OWL.imports, None))
 graph.remove((None, rdflib.RDF.type, rdflib.OWL.Ontology))
 graph.add((REF, rdflib.RDF.type, rdflib.OWL.Ontology))
 for ont, imp in graph.subject_objects(rdflib.OWL.imports):


### PR DESCRIPTION
Single namespace will be much easier to use and remember. Will require changing a couple property names (`ifc:name` becomes `ref:ifcName`) but nothing too odious