### PR TITLE
Rank references

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -35,11 +35,14 @@ jobs:
       run: |
         mkdir build
         poetry run python tools/compile.py
+    - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H:%M:%S')"
     - uses: marvinpinto/action-automatic-releases@latest
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         prerelease: true
-        automatic_release_tag: nightly
+        automatic_release_tag: nightly-${{ steps.date.outputs.date }}
         title: Nightly Build ${{ steps.date.outputs.date }}
         files: |
           build/ref-schema.ttl

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: test
 
-compile: model/*.ttl test
+compile: model/*.ttl
 	poetry run python tools/compile.py
 
-test:
+test: compile
 	poetry run pytest -s -vvvv
 
-docs: compile
+doc.html:
 	poetry run pylode build/ref-schema.ttl -o doc.html -c true

--- a/examples/ex1.ttl
+++ b/examples/ex1.ttl
@@ -2,7 +2,7 @@
 @prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix s223: <http://data.ashrae.org/standard223#> .
 @prefix bacnet: <http://data.ashrae.org/bacnet/2020#> .
-@prefix : <urn:ex1> .
+@prefix : <urn:ex1/> .
 
 <urn:ex1>
   a owl:Ontology ;
@@ -19,7 +19,6 @@
     a ref:TimeseriesReference ;
     ref:hasTimeseriesId "4665117e-ec75-47c2-a5ce-b71529cb159e" ;
     ref:storedAt "postgresql://dataserver/sensordatadb" ;
-    ref:preferred true ;
   ] ;
   ref:hasExternalReference [
     a ref:BACnetReference ;

--- a/examples/ex1.ttl
+++ b/examples/ex1.ttl
@@ -25,5 +25,6 @@
     bacnet:object-identifier "analog-value,5" ;
     bacnet:object-name "BLDG-Z410-ZATS" ;
     bacnet:objectOf :sample-device ;
+    ref:preferred true ;
   ] ;
 .

--- a/examples/ex1.ttl
+++ b/examples/ex1.ttl
@@ -19,6 +19,7 @@
     a ref:TimeseriesReference ;
     ref:hasTimeseriesId "4665117e-ec75-47c2-a5ce-b71529cb159e" ;
     ref:storedAt "postgresql://dataserver/sensordatadb" ;
+    ref:preferred true ;
   ] ;
   ref:hasExternalReference [
     a ref:BACnetReference ;

--- a/model/core.ttl
+++ b/model/core.ttl
@@ -28,11 +28,16 @@ ref:preferred a owl:DatatypeProperty ;
 ref:PreferredShape a sh:NodeShape ;
     sh:targetSubjectsOf ref:hasExternalReference ;
     sh:property [
-        sh:path (ref:hasExternalReference ref:preferred) ;
-        sh:datatype xsd:boolean ;
-        sh:hasValue true ;
+        sh:path ref:hasExternalReference ;
+        sh:qualifiedValueShape [
+            sh:class ref:ExternalReference ;
+            sh:property [
+                sh:path ref:preferred ;
+                sh:datatype xsd:boolean ;
+                sh:hasValue true ;
+            ] ;
+        ] ;
         sh:message "An entity can only have one 'preferred' External Reference" ;
-        sh:minCount 0 ;
-        sh:maxCount 1 ;
+        sh:qualifiedMaxCount 1 ;
     ] ;
 .

--- a/model/core.ttl
+++ b/model/core.ttl
@@ -20,3 +20,19 @@ ref:hasExternalReference a owl:ObjectProperty ;
     rdfs:label "hasExternalReference" ;
     skos:definition "Points to the external reference for this entity, which contains additional metadata/data not included in this graph." ;
 .
+
+ref:preferred a owl:DatatypeProperty ;
+    skos:definition "An entity can have one 'preferred' External Reference. Consumers of the model should prioritize any external reference with the 'preferred' property" ;
+.
+
+ref:PreferredShape a sh:NodeShape ;
+    sh:targetSubjectsOf ref:hasExternalReference ;
+    sh:property [
+        sh:path (ref:hasExternalReference ref:preferred) ;
+        sh:datatype xsd:boolean ;
+        sh:hasValue true ;
+        sh:message "An entity can only have one 'preferred' External Reference" ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/model/ranking.ttl
+++ b/model/ranking.ttl
@@ -13,11 +13,16 @@ ref:preferred a owl:DatatypeProperty ;
 .
 
 ref:PreferredShape a sh:NodeShape ;
-    sh:targetSubjectsOf ref:preferred ;
+    sh:targetSubjectsOf ref:hasExternalReference ;
     sh:property [
-        sh:path ref:preferred ;
+        sh:path ref:xyz ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        sh:path (ref:hasExternalReference ref:preferred) ;
         sh:datatype xsd:boolean ;
-        sh:minCount 0 ;
-        sh:maxCount 1 ;
+        sh:hasValue true ;
+        sh:message "An entity can only have one 'preferred' External Reference" ;
+        sh:maxCount 0 ;
     ] ;
 .

--- a/model/ranking.ttl
+++ b/model/ranking.ttl
@@ -1,0 +1,23 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix sdo: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ref:preferred a owl:DatatypeProperty ;
+    skos:definition "An entity can have one 'preferred' External Reference. Consumers of the model should prioritize any external reference with the 'preferred' property" ;
+.
+
+ref:PreferredShape a sh:NodeShape ;
+    sh:targetSubjectsOf ref:preferred ;
+    sh:property [
+        sh:path ref:preferred ;
+        sh:datatype xsd:boolean ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,7 +6,6 @@ import os
 import logging
 import rdflib
 import pyshacl
-import ontoenv
 from warnings import warn
 
 logger = logging.getLogger(__name__)
@@ -19,13 +18,12 @@ def test_data_validation(data_file):
 
     WARNS but does not fail the test on a validation error for a shape with sh:Info severity
     """
-    env = ontoenv.OntoEnv()
     data_graph = rdflib.Graph()
 
     # validate each data file independently
     data_graph.parse(data_file, format="turtle")
-    # load in all dependent data validation and model definition shapes
-    env.import_dependencies(data_graph)
+    # load in ref-schema
+    data_graph.parse("build/ref-schema.ttl", format="turtle")
     logger.info("Validating data definition of %s ( %d triples)", data_file, len(data_graph))
     valid, x, res_text = pyshacl.validate(
         data_graph=data_graph, advanced=True, js=True, allow_warnings=True


### PR DESCRIPTION
Optionally add 'preferred' label to ExternalReference instances:

```ttl
<urn:ex1>
  a owl:Ontology ;
  owl:imports <https://brickschema.org/schema/Brick/ref#> ;
.

:sample-device a bacnet:BACnetDevice ;
    bacnet:device-instance 123 ;
    # is this correct?
    bacnet:hasPort [ a bacnet:Port ; bacnet:value 47808 ] .

:xyz a s223:Property ;
  ref:hasExternalReference [
    a ref:TimeseriesReference ;
    ref:hasTimeseriesId "4665117e-ec75-47c2-a5ce-b71529cb159e" ;
    ref:storedAt "postgresql://dataserver/sensordatadb" ;
  ] ;
  ref:hasExternalReference [
    a ref:BACnetReference ;
    bacnet:object-identifier "analog-value,5" ;
    bacnet:object-name "BLDG-Z410-ZATS" ;
    bacnet:objectOf :sample-device ;
    ref:preferred true ;
  ] ;
.
```

I added a rule that enforces a maximum of 1 'preferred' ExternalReference per entity. @epaulson what do you think?